### PR TITLE
Fix crash when enumerating lights that don't have a brightness atrribute

### DIFF
--- a/lib/hue/extensions/bulb.rb
+++ b/lib/hue/extensions/bulb.rb
@@ -8,7 +8,7 @@ module Hue
       spaces = 4
       puts "#{self.id}.".ljust(spaces) + "#{self.name}: #{self.on? ? 'ON' : 'OFF'}"
       indent(spaces) do
-        puts "Brightness: #{self.brightness} (#{(self.brightness_percent).to_i}%)"
+        puts "Brightness: #{self.brightness} (#{(self.brightness_percent).to_i}%)" if self.brightness
         puts "Color: #{self.color}, #{self.color.to_rgb}" if self.state["hue"]
         transitory_state = [
           (self.transition_time > 0 ? "Transition time: #{self.transition_time} sec" : nil),


### PR DESCRIPTION
Some devices do not have a brightness, such as switches:

```
$ hue 23 dump   # A switched outlet
{"on":true,"alert":"none","mode":"homeautomation","reachable":true}

$ hue 2 dump  # A light
{"on":false,"bri":76,"ct":367,"alert":"none","colormode":"ct","mode":"homeautomation","reachable":true}

$ hue | egrep '( 2\.|23\.)'
     2. D1 Bulb                          OFF     LTW011 - Color temperature light
    23. Fish Light                       ON      LXN56-0S27LX1.1 - On/Off light
```
This causes the `hue lights` command to crash when trying to access the `brightness` method.  This small change prevents the crash and allows `hue lights` to continue.

