### PR TITLE
reproducible dev environment via flakes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1691313029,
+        "narHash": "sha256-JCdafAmmuOkcRGFEUkXckRZ3Q/PBBtcm1Mq0GBA3XEY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0bab81e6319eb418e1509fe4b88401a022f3bf99",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  description = "A Nix-flake-based Ruby development environment";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    supportedSystems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+    forEachSupportedSystem = f:
+      nixpkgs.lib.genAttrs supportedSystems (system:
+        f {
+          pkgs = import nixpkgs {inherit system;};
+        });
+  in {
+    devShells = forEachSupportedSystem ({pkgs}: {
+      default = pkgs.mkShell {
+        packages = with pkgs; [ruby_3_2];
+      };
+    });
+  };
+}

--- a/hue-cli.gemspec
+++ b/hue-cli.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency("json")
+  s.add_runtime_dependency("json", '>= 2.6.1')
   s.add_runtime_dependency("hue-lib", '>= 0.7.4')
   s.add_development_dependency("rspec", '>= 2.6.0')
   s.add_development_dependency("mocha", '>= 0.9.0')


### PR DESCRIPTION
- adding flakes to allow us nix people to work on this without installing ruby into our main environment
- updated json dependency but my flake isn't connected to your gemfile at the moment because 

I still get the same deprecated warning from Ruby that looks like this on my system:

```
/nix/store/j1c8qr0ry0ilqz069m76zqkwk2cnvjl8-ruby2.7.6-json-2.2.0/lib/ruby/gems/2.7.0/gems/json-2.2.0/lib/json/common.rb:156: warning: Using the last argument as keyword parameters is deprecated
/nix/store/j1c8qr0ry0ilqz069m76zqkwk2cnvjl8-ruby2.7.6-json-2.2.0/lib/ruby/gems/2.7.0/gems/json-2.2.0/lib/json/common.rb:156: warning: Using the last argument as keyword parameters is deprecated
```
